### PR TITLE
Adds the string size to the mqtt_utf8 password struct

### DIFF
--- a/subsys/shell/shell_mqtt.c
+++ b/subsys/shell/shell_mqtt.c
@@ -343,7 +343,7 @@ static void broker_init(struct shell_mqtt *ctx)
 	zsock_inet_pton(AF_INET, SERVER_ADDR, &broker4->sin_addr);
 }
 
-static struct mqtt_utf8 password = { .utf8 = MQTT_PASSWORD };
+static struct mqtt_utf8 password = { .utf8 = MQTT_PASSWORD, .size = sizeof(MQTT_PASSWORD) };
 
 static struct mqtt_utf8 username = { .utf8 = MQTT_USERNAME, .size = sizeof(MQTT_USERNAME) };
 


### PR DESCRIPTION
The `mqtt_utf8` struct for the broker password did not have the size field set.